### PR TITLE
Countdown, enemy selection and refactoring

### DIFF
--- a/Assets/Gameplay_Scenes/bullet.tscn
+++ b/Assets/Gameplay_Scenes/bullet.tscn
@@ -59,7 +59,7 @@ tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
 "times": PackedFloat32Array(0, 0.1, 0.5),
-"transitions": PackedFloat32Array(1.23114, 0.482968, 1),
+"transitions": PackedFloat32Array(1.23114, 1, 1),
 "update": 0,
 "values": [Vector3(1, 1, 1), Vector3(1.3, 1.3, 1.3), Vector3(0.1, 0.1, 0.1)]
 }

--- a/Assets/Gameplay_Scenes/enemy_test.tscn
+++ b/Assets/Gameplay_Scenes/enemy_test.tscn
@@ -69,7 +69,19 @@ tracks/0/keys = {
 "times": PackedFloat32Array(0, 0.15, 0.2, 0.4),
 "transitions": PackedFloat32Array(1, 0.5, 1.23114, 1),
 "update": 0,
-"values": [Vector3(0, 0, 0), Vector3(0.174533, 0, 0), Vector3(0.244346, 0, 0), Vector3(0, 0, 0)]
+"values": [Vector3(0, 0, 0), Vector3(0.0872665, 0, 0), Vector3(0.174533, 0, 0), Vector3(0, 0, 0)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath(".:scale")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.15, 0.4),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector3(1, 1, 1), Vector3(0.7, 0.7, 0.7), Vector3(1, 1, 1)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_5d5q4"]
@@ -135,4 +147,3 @@ libraries = {
 }
 script = ExtResource("7_tqity")
 signals = Array[ExtResource("8_6xcnt")]([SubResource("Resource_m6trv")])
-is_valid = true

--- a/Assets/Gameplay_Scenes/map_generation.tscn
+++ b/Assets/Gameplay_Scenes/map_generation.tscn
@@ -13,7 +13,7 @@
 [node name="MapGeneration" type="Node3D" node_paths=PackedStringArray("grid_generation", "path_generation", "main_building")]
 script = ExtResource("1_1g4sv")
 grid_generation = NodePath("Grid Generator")
-path_generation = NodePath("EnemyPath")
+path_generation = NodePath("PathComponent")
 main_building = NodePath("PlayerMainBuilding")
 grid_size = Vector2i(1, 1)
 path_straight_mesh = ExtResource("2_0n20a")
@@ -24,10 +24,10 @@ path_corner_mesh = ExtResource("4_som84")
 
 [node name="Grid Generator" parent="." instance=ExtResource("1_yv21r")]
 
-[node name="EnemyPath" parent="." instance=ExtResource("2_l1v4g")]
+[node name="PathComponent" parent="." instance=ExtResource("2_l1v4g")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.1, 0)
 
 [node name="EnemyManager" type="Node" parent="." node_paths=PackedStringArray("path")]
 script = ExtResource("4_gsnwd")
-path = NodePath("../EnemyPath")
+path = NodePath("../PathComponent")
 waves_data = ExtResource("9_pue8y")

--- a/Assets/Gameplay_Scenes/path.tscn
+++ b/Assets/Gameplay_Scenes/path.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3 uid="uid://csas3v1hcvwsg"]
 
-[ext_resource type="Script" path="res://Scripts/Components/Path_Components/EnemyPathComponent.gd" id="1_0eo62"]
+[ext_resource type="Script" path="res://Scripts/Components/Path_Components/PathComponent.gd" id="1_0eo62"]
 
 [sub_resource type="Curve3D" id="Curve3D_oaoi5"]
 bake_interval = 1.0

--- a/Assets/UI/UI_Scenes/ui_game.tscn
+++ b/Assets/UI/UI_Scenes/ui_game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://dhvxplh8y7foq"]
+[gd_scene load_steps=8 format=3 uid="uid://dhvxplh8y7foq"]
 
 [ext_resource type="Script" path="res://Scripts/UI/UIGame.gd" id="1_3gav5"]
 [ext_resource type="Theme" uid="uid://ch35pidq376ny" path="res://Assets/UI/Themes/theme_ui.tres" id="2_2p4bm"]
@@ -6,8 +6,9 @@
 [ext_resource type="Resource" uid="uid://hsytkkst11qo" path="res://Resources/PlaceableObjects/PlaceablesAndUI/placeable_test_ui.tres" id="3_77583"]
 [ext_resource type="PackedScene" uid="uid://cqrc5aq7pgx0n" path="res://Assets/UI/UI_Scenes/build_option.tscn" id="3_orx4t"]
 [ext_resource type="Resource" uid="uid://bekv6fk1b0845" path="res://Resources/PlaceableObjects/PlaceablesAndUI/placeable_test_ui_two.tres" id="4_i64dq"]
+[ext_resource type="PackedScene" uid="uid://cku2g10r5mp1u" path="res://Assets/UI/UI_Scenes/ui_wave_countdown.tscn" id="7_dhu8f"]
 
-[node name="UIGame" type="Control" node_paths=PackedStringArray("canvas", "money_label", "health_label", "bottom_section", "build_tab")]
+[node name="UIGame" type="Control" node_paths=PackedStringArray("canvas", "money_label", "health_label", "wave_countdown_label", "bottom_section", "build_tab")]
 clip_contents = true
 layout_mode = 3
 anchors_preset = 15
@@ -21,6 +22,7 @@ canvas = NodePath("CanvasLayer")
 lose_screen = ExtResource("2_hegv0")
 money_label = NodePath("CanvasLayer/MoneyContainer/MoneyLabel")
 health_label = NodePath("CanvasLayer/HealthContainer/HealthLabel")
+wave_countdown_label = NodePath("CanvasLayer/UiWaveCountdown")
 bottom_section = NodePath("CanvasLayer/TabContainer")
 build_tab = NodePath("CanvasLayer/TabContainer/Build")
 spacer_size = 5
@@ -29,6 +31,8 @@ preloaded_build_options = Array[Resource("res://Scripts/Resources/Placeables/Pla
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 follow_viewport_enabled = true
+
+[node name="UiWaveCountdown" parent="CanvasLayer" instance=ExtResource("7_dhu8f")]
 
 [node name="MoneyContainer" type="PanelContainer" parent="CanvasLayer"]
 custom_minimum_size = Vector2(132, 51)

--- a/Assets/UI/UI_Scenes/ui_wave_countdown.tscn
+++ b/Assets/UI/UI_Scenes/ui_wave_countdown.tscn
@@ -1,0 +1,14 @@
+[gd_scene format=3 uid="uid://cku2g10r5mp1u"]
+
+[node name="UiWaveCountdown" type="Label"]
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -82.5
+offset_right = 82.5
+offset_bottom = 31.0
+grow_horizontal = 2
+theme_override_font_sizes/font_size = 20
+text = "Wave starts in: "
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/Resources/EnemyWaves/test_waves.tres
+++ b/Resources/EnemyWaves/test_waves.tres
@@ -11,20 +11,21 @@ script = ExtResource("2_3rurf")
 _enemy_definition = ExtResource("1_gmogh")
 _is_first_spawn_instant = true
 _enemy_count = 2
-_spawn_rate = 3.0
+_spawn_rate = 1.0
 _spawn_delay = 1.0
 
 [sub_resource type="Resource" id="Resource_1phy8"]
 script = ExtResource("2_3rurf")
 _enemy_definition = ExtResource("3_b34dd")
-_is_first_spawn_instant = false
-_enemy_count = 0
-_spawn_rate = 3.0
+_is_first_spawn_instant = true
+_enemy_count = 4
+_spawn_rate = 0.6
 _spawn_delay = 1.0
 
 [sub_resource type="Resource" id="Resource_540js"]
 script = ExtResource("3_d6omo")
 _enemies_spawn_data = Array[ExtResource("2_3rurf")]([SubResource("Resource_8khny"), SubResource("Resource_1phy8")])
+_wave_start_delay = 3.0
 
 [resource]
 script = ExtResource("2_f1yfi")

--- a/Scripts/Components/AttackComponent.gd
+++ b/Scripts/Components/AttackComponent.gd
@@ -90,10 +90,35 @@ func _start_animation(target : Node3D) -> void:
 	
 
 func _select_target() -> Enemy:
-	var target: Enemy = available_targets.front() as Enemy
-	assert(target, "Timer should be disabled when all targets are removed")
+	var target: Enemy
+	if available_targets.is_empty():
+		assert(target, "Timer should be disabled when all targets are removed")
+		return target
+	
+	match(target_priority):
+		FocusPriority.First:
+			target = _get_first_target()
+		FocusPriority.Last:
+			target = _get_last_target()
+		FocusPriority.Random:
+			target = _get_random_target()
+	
 	selected_target.emit(target)
 	return target
+	
+
+func _get_first_target() -> Enemy:
+	var enemy_manager: EnemyManager = GameManager.get_enemy_manager()
+	return enemy_manager.get_most_distance_travelled_enemy(available_targets)
+	
+
+func _get_last_target() -> Enemy:
+	var enemy_manager: EnemyManager = GameManager.get_enemy_manager()
+	return enemy_manager.get_least_distance_travelled_enemy(available_targets)
+	
+
+func _get_random_target() -> Enemy:
+	return available_targets.pick_random()
 	
 
 func _set_current_target() -> void:

--- a/Scripts/Components/Path_Components/PathComponent.gd
+++ b/Scripts/Components/Path_Components/PathComponent.gd
@@ -1,7 +1,7 @@
-class_name EnemyPathComponent
+class_name PathComponent
 extends Path3D
 
-signal updated_movement(path_handler : EnemyPathComponent, delta : float)
+signal updated_movement(path_handler : PathComponent, delta : float)
 signal completed_path(follower : Node3D)
 
 @export_category("Dependencies")

--- a/Scripts/Components/Path_Components/PathFollowerComponent.gd
+++ b/Scripts/Components/Path_Components/PathFollowerComponent.gd
@@ -11,9 +11,9 @@ func is_valid() -> bool:
 	return _target and is_instance_valid(_target)
 	
 
-func update_distance_traveled(path_handler : EnemyPathComponent, delta : float):
+func update_distance_traveled(path_handler : PathComponent, delta : float):
 	_distance_traveled += speed * delta
-	var path_data: EnemyPathComponent.PathTravelData = path_handler.get_position_data_along_path(_distance_traveled)
+	var path_data: PathComponent.PathTravelData = path_handler.get_position_data_along_path(_distance_traveled)
 	_target.global_position = path_data.position
 	
 	if path_data.is_path_completed:
@@ -28,4 +28,8 @@ func set_path_follower(set_target : Node3D) -> void:
 		
 	
 	_target = set_target
+	
+
+func has_travelled_further_than(other_path_follower : PathFollowerComponent) -> bool:
+	return _distance_traveled > other_path_follower._distance_traveled
 	

--- a/Scripts/EnemyManager.gd
+++ b/Scripts/EnemyManager.gd
@@ -2,10 +2,11 @@ class_name EnemyManager
 extends Node
 
 @export_category("Dependencies")
-@export var path: EnemyPathComponent
+@export var path: PathComponent
 @export var waves_data: EnemyWavesData
 
 func _ready() -> void:
+	GameManager.set_enemy_manager(self)
 	await get_parent().ready
 	_spawn_and_setup_wave_enemies()
 	
@@ -16,16 +17,53 @@ func _process(delta):
 		waves_data.reduce_spawn_rate_timer_by(delta)
 	
 
+func get_most_distance_travelled_enemy(enemies : Array[Enemy]) -> Enemy:
+	if enemies.is_empty():
+		return null
+	
+	var current_match: Enemy
+	for enemy in enemies:
+		if current_match:
+			if enemy.path_follower.has_travelled_further_than(current_match.path_follower):
+				current_match = enemy
+		else:
+			current_match = enemy
+		
+	
+	return current_match
+
+func get_least_distance_travelled_enemy(enemies : Array[Enemy]) -> Enemy:
+	if enemies.is_empty():
+		return null
+	
+	var current_match: Enemy
+	for enemy in enemies:
+		if current_match:
+			if not enemy.path_follower.has_travelled_further_than(current_match.path_follower):
+				current_match = enemy
+		else:
+			current_match = enemy
+		
+	
+	return current_match
+	
+
 func _spawn_and_setup_wave_enemies() -> void:
 	if not waves_data or not waves_data.is_valid():
 		printerr("No waves setup")
 		return
 	
 	# TEST: For testing that it follows path correctly
-	waves_data.start_wave_spawning_at(path.get_beginning_of_path_position(), self)
-	waves_data.enemy_spawned.connect(setup_spawned_enemy.bind())
+	waves_data.wave_spawn_started.connect(_wave_officially_started)
+	var current_wave = waves_data.start_wave_spawning_at(path.get_beginning_of_path_position(), self)
+	waves_data.enemy_spawned.connect(_setup_spawned_enemy.bind())
+	UIEvents.wave_countdown_started.emit(current_wave._wave_start_delay)
 	
 
-func setup_spawned_enemy(enemy : Enemy) -> void:
+func _setup_spawned_enemy(enemy : Enemy) -> void:
 	path.add_path_follower_listener(enemy.path_follower)
+	
+
+func _wave_officially_started() -> void:
+	GameEvents.wave_spawning_started.emit()
 	

--- a/Scripts/MapGeneration.gd
+++ b/Scripts/MapGeneration.gd
@@ -2,7 +2,7 @@ extends Node3D
 
 @export_category("Dependencies")
 @export var grid_generation: GridComponent
-@export var path_generation: EnemyPathComponent
+@export var path_generation: PathComponent
 @export var main_building: PlayerMainBuilding
 
 @export_category("Configuration")

--- a/Scripts/PlayerScripts/PlayerMainBuilding.gd
+++ b/Scripts/PlayerScripts/PlayerMainBuilding.gd
@@ -13,7 +13,7 @@ func _ready():
 	UIEvents.update_player_health(health_component.health)
 	
 
-func setup_building_connections(path : EnemyPathComponent) -> void:
+func setup_building_connections(path : PathComponent) -> void:
 	path.completed_path.connect(_handle_entering_node.bind())
 	
 

--- a/Scripts/Resources/Waves/WaveSpawnData.gd
+++ b/Scripts/Resources/Waves/WaveSpawnData.gd
@@ -3,7 +3,9 @@ extends Resource
 
 @export_category("Per Wave Configuration")
 @export var _enemies_spawn_data: Array[EnemySpawnData]
+@export var _wave_start_delay: float
 
 func _init():
 	_enemies_spawn_data.append(EnemySpawnData.new())
 	
+

--- a/Scripts/Singleton/GameEventsBus.gd
+++ b/Scripts/Singleton/GameEventsBus.gd
@@ -1,3 +1,5 @@
 extends Node
 
 signal update_selected_placeable(placeable_data : PlaceableData)
+
+signal wave_spawning_started

--- a/Scripts/Singleton/GameManagerSingleton.gd
+++ b/Scripts/Singleton/GameManagerSingleton.gd
@@ -11,7 +11,21 @@ enum GameStates
 	Lost,
 }
 
+var enemy_manager: EnemyManager
 var current_state: GameStates = GameStates.Play
+
+func get_enemy_manager() -> EnemyManager:
+	return enemy_manager
+	
+
+func set_enemy_manager(manager : EnemyManager) -> void:
+	if not is_instance_valid(manager):
+		assert(false, "Don't set enemy manager to invalid reference")
+		return
+	
+	assert(!enemy_manager, "Enemy manager is already set, it shouldn't be set twice")
+	enemy_manager = manager
+	
 
 func try_update_game_state(new_state : GameStates) -> bool:
 	if not _is_state_valid_transition(new_state):
@@ -19,9 +33,19 @@ func try_update_game_state(new_state : GameStates) -> bool:
 		return false
 	
 	current_state = new_state
-	handle_state_transition()
+	_handle_state_transition()
 	
 	return true
+
+
+func _handle_state_transition() -> void:
+	match(current_state):
+		GameStates.Lost:
+			lost_game.emit()
+		GameStates.Play:
+			## TEST: For now just reload scene
+			get_tree().reload_current_scene()
+	
 
 func _is_state_valid_transition(state : GameStates) -> bool:
 	if current_state == state:
@@ -36,12 +60,3 @@ func _is_state_valid_transition(state : GameStates) -> bool:
 			return current_state == GameStates.Play
 	
 	return false
-
-func handle_state_transition() -> void:
-	match(current_state):
-		GameStates.Lost:
-			lost_game.emit()
-		GameStates.Play:
-			## TEST: For now just reload scene
-			get_tree().reload_current_scene()
-	

--- a/Scripts/Singleton/UINotifierSingleton.gd
+++ b/Scripts/Singleton/UINotifierSingleton.gd
@@ -4,6 +4,8 @@ extends Node
 
 signal player_health_updated(value : int)
 
+signal wave_countdown_started(time : float)
+
 func update_player_health(value : int) -> void:
 	player_health_updated.emit(value)
 	

--- a/Scripts/UI/UIGame.gd
+++ b/Scripts/UI/UIGame.gd
@@ -5,9 +5,10 @@ extends Control
 @export var canvas: CanvasLayer
 @export_subgroup("Overlay UI")
 @export var lose_screen: PackedScene
-@export_subgroup("Top Left Section")
+@export_subgroup("Top Section")
 @export var money_label: Label
 @export var health_label: Label
+@export var wave_countdown_label: Label
 @export_subgroup("Bottom Section")
 @export var bottom_section: TabContainer
 @export var build_tab: HBoxContainer
@@ -21,7 +22,11 @@ extends Control
 func _ready():
 	Economy.money_changed.connect(set_money_label.bind())
 	UIEvents.player_health_updated.connect(set_health_label.bind())
+	UIEvents.wave_countdown_started.connect(display_wave_countdown.bind())
 	GameManager.lost_game.connect(display_lost_screen.bind())
+	GameEvents.wave_spawning_started.connect(hide_countdown.bind())
+	
+	assert(wave_countdown_label)
 	
 	for build_option in preloaded_build_options:
 		add_build_option(build_option)
@@ -62,3 +67,11 @@ func add_build_option(complete_placeable_data : PlaceableAndUIData) -> void:
 	build_option.setup_option_ui(complete_placeable_data)
 	
 
+func display_wave_countdown(time : float) -> void:
+	wave_countdown_label.visible = true
+	wave_countdown_label.text = "Wave starts in: %s" % time
+	
+
+func hide_countdown() -> void:
+	wave_countdown_label.visible = false
+	


### PR DESCRIPTION
## Description
Target selection when attacking had an enum to determine the selection priority but the logic was missing, this PR adds a basic prototype.

Waves would instantly start, I decided to add a countdown before the wave would start.

`EnemyPathComponent` was a very specialized name for a component that only handles a generic path, so I decided to rename it to `PathComponent` to better reflect the generic focus of the component.

## Summary of Changes
### UI
- Created UI scene for countdown
- Added UI for the countdown on the `UIGame` scene overlay
- Added new UI event for wave countdown started


### Gameplay
- Updated `AttackComponent` to select a target correctly following the set focus using targets travel distance.
- Updated `EnemyManager` to let it handle enemy queries, in this case to check from a list of targets which has travelled the most or least distance.
- Updated `PathFollowerComponent` to be able to check distance travelled between two components
- Updated `GameManager` autoload to store a reference to the `EnemyManager`

#### Waves
- Updated wave resources to support a delay before a wave starts spawning
- Updated waves for testing
- Created game event for wave started

> [!NOTE]
> I wanted to instead use a reusable predicate to loot on an array of enemies, so I may update this on a separate PR

### Refactoring 
- Renamed `EnemyPathComponent` to `PathComponent`
- Updated method names to reflect their private use

### Bug Fixing
- Towers now selects the correct enemy

